### PR TITLE
merged linux and macos #!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1414,10 +1414,8 @@ for el in Bar.foreach([1, 2, 3]):
 Basic Script Template
 ---------------------
 ```python
-# Linux:
+# Linux or macOS
 #!/usr/bin/env python3
-# Mac:
-#!/usr/local/bin/python3
 #
 # Usage: .py 
 # 


### PR DESCRIPTION
Both linux and macOS can launch Python3 the same way.