### PR TITLE
updated itertools

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,28 +902,28 @@ Itertools
 **Every function returns an iterator and can accept any collection and/or iterator. If you want to print the iterator, you need to pass it to the list() function.**
 
 ```python
-from itertools import *
+import itertools
 ```
 
 ### Combinatoric iterators
 ```python
->>> combinations('abc', 2)
+>>> list(itertools.combinations('abcd', 2))
 [('a', 'b'), ('a', 'c'), ('b', 'c')]
 
->>> combinations_with_replacement('abc', 2)
+>>> itertools.combinations_with_replacement('abc', 2)
 [('a', 'a'), ('a', 'b'), ('a', 'c'), 
  ('b', 'b'), ('b', 'c'), ('c', 'c')]
 
->>> permutations('abc', 2)
+>>> itertools.permutations('abc', 2)
 [('a', 'b'), ('a', 'c'), 
  ('b', 'a'), ('b', 'c'), 
  ('c', 'a'), ('c', 'b')]
 
->>> product('ab', [1, 2])
+>>> itertools.product('ab', [1, 2])
 [('a', 1), ('a', 2), 
  ('b', 1), ('b', 2)]
 
->>> product([0, 1], repeat=3)
+>>> itertools.product([0, 1], repeat=3)
 [(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1), 
  (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
 ```


### PR DESCRIPTION
I went to try this.. and found that the `from itertools import *` makes the call to itertools invisible, and totally not obvious to a newbie like me! I'm ok with just 'import itertools' and then being explicit. Huh. Ok, I just referenced the Zen of Python.. must have reached newbie level 2!

Could not get first example to show the result as I needed the right incantation of list(itertools.combinations('abc', 2)), so I added it as an example.

May be worth it to tweak things just a little.. and only keep something like my version of line 910 and ignore the rest :-)