### PR TITLE
Small correction to <str>.strip('<chars>')

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ String
 ------
 ```python
 <str>  = <str>.strip()           # Strips all whitespace characters.
-<str>  = <str>.strip('<chars>')  # Strips all passed characters.
+<str>  = <str>.strip('<chars>')  # Strips all passed characters from start and end.
 ```
 
 ```python


### PR DESCRIPTION
Removes \<chars\> from start up to first non-\<chars\> and from end to last non-\<chars\>.

https://www.programiz.com/python-programming/methods/string/strip