### PR TITLE
Slight correction to <str>.strip descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ from numbers import Number, Integral, Real, Rational, Complex
 String
 ------
 ```python
-<str>  = <str>.strip()           # Strips all whitespace characters.
-<str>  = <str>.strip('<chars>')  # Strips all passed characters.
+<str>  = <str>.strip()           # Strips all whitespace characters from start and end.
+<str>  = <str>.strip('<chars>')  # Strips all passed characters from start and end.
 ```
 
 ```python


### PR DESCRIPTION
Removes \<chars\> (or whitespace) from start of \<str\> up to the first
non-\<chars\> and from the end of \<str\> up to the last non-\<chars\>.

[Python 3 Docs](https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip)