### PR TITLE
Fix element skipping for empty iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Iterator
 
 #### Skips first element:
 ```python
-next(<iter>)
+next(<iter>, None)  # default of `None` avoids exception for empty <iter>
 for element in <iter>:
     ...
 ```


### PR DESCRIPTION
`next(<iter>)` raises `StopIteration` when the iterator is empty. Providing a default returns that value instead, allowing to skip elements gracefully when you don't care if they exist.