### PR TITLE
Qualify list deduplication snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sorted_by_both   = sorted(<collection>, key=lambda el: (el[1], el[0]))
 flattened_list   = list(itertools.chain.from_iterable(<list>))
 list_of_chars    = list(<str>)
 product_of_elems = functools.reduce(lambda out, x: out * x, <collection>)
-no_duplicates    = list(dict.fromkeys(<list>))
+no_duplicates    = list(dict.fromkeys(<list>))  # hashables only; order guaranteed since Py3.7+
 ```
 
 ```python


### PR DESCRIPTION
As other people mentioned in the recent Hacker News discussion, `dict.fromkeys(<list>)` does not preserve order in all common versions of even Python 3. The snippet will also fail if `<list>` contains unhashable items. I think it's fair to warn people of these restrictions in advance.