### PR TITLE
Implement website designe changes requested in #23

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -138,7 +138,7 @@ textarea {
   font-size: 100%;
 }
 
-body > pre {
+pre {
   border-left: solid 2px #ccc;
   padding-left: 18px;
   margin: 2em 0 2em 0;
@@ -224,8 +224,9 @@ h3,
 h4,
 p,
 ul {
-  padding-left: 2rem;
+  padding-left: 1.2rem;
 }
+
 .banner {
   padding: 0;
 }
@@ -235,9 +236,26 @@ ul {
 }
 
 @media only screen and (max-device-width: 1024px) {
-  h1 {
-    font-size: 3rem;
+  .ocks-org body {
+    font-size: 80%;
+    padding: 0.5rem;
   }
+
+  h3,
+  h4,
+  p,
+  ul {
+    padding-left: .7rem;
+  }
+
+  h1 {
+    font-size: 2rem;
+  }
+
+  pre {
+    padding-left: 0.5rem;
+  }
+
   .banner,
   h1,
   img {


### PR DESCRIPTION
I implemented the changes you requested in #23.

Now the `h3`, `h4`, `p` and `ul` tags are better aligned  and ~50 cols are displayed on mobile.
I wouldn't go smaller with the font, but you can play around with it in the media query at the end of `style.css` (`font-size: 80%;`)

Desktop:
![cheatsheet_desktop](https://user-images.githubusercontent.com/9513634/55100893-3506e580-50c3-11e9-9067-01467b68e9f5.jpg)

Mobile:
![cheatsheet_mobile](https://user-images.githubusercontent.com/9513634/55100902-39330300-50c3-11e9-8864-e4525e0349e3.jpg)
