### PR TITLE
Fixed 2 issues of type: PYTHON_W291 throughout 1 file in repo.

### DIFF
--- a/web/empty_script.py
+++ b/web/empty_script.py
@@ -5,8 +5,8 @@
 # How about:
 from math import sin, pi
 LEN = 40
-wave = ['#' * (1 + round(amp * (1+sin(i/resolution*2*pi)))) 
-            for resolution, amp in zip(range(10, 10+LEN, 2), range(2, 2+LEN, 2)) 
+wave = ['#' * (1 + round(amp * (1+sin(i/resolution*2*pi))))
+            for resolution, amp in zip(range(10, 10+LEN, 2), range(2, 2+LEN, 2))
                 for i in range(resolution)]
 print('\n'.join(wave))
 


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.