### PR TITLE
Remove minimum-scale on viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Comprehensive Python Cheatsheet</title>
   <meta name="description" content="Exhaustive, simple, beautiful and concise. A truly pythonic cheat sheet about Python programming language.">
   <link rel="icon" href="web/favicon.png">

--- a/web/template.html
+++ b/web/template.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Comprehensive Python Cheatsheet</title>
   <meta name="description" content="Exhaustive, simple, beautiful and concise. A truly pythonic cheat sheet about Python programming language.">
   <link rel="icon" href="web/favicon.png">


### PR DESCRIPTION
Because it caused mobile accessibility issues.

Confirmed to allow for proper zoom on Safari 12.1 and Chrome 75