### PR TITLE
"Cheatsheet" are two words and not one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Comprehensive Python Cheatsheet
+Comprehensive Python Cheat Sheet
 ===============================
 <sup>[Download text file](https://raw.githubusercontent.com/gto76/python-cheatsheet/master/README.md), [Buy PDF](https://transactions.sendowl.com/products/78175486/4422834F/view), [Fork me on GitHub](https://github.com/gto76/python-cheatsheet) or [Check out FAQ](https://github.com/gto76/python-cheatsheet/wiki/Frequently-Asked-Questions).
 </sup>


### PR DESCRIPTION
It really is a preference if "Python Cheatsheet" is the name of the project then it's fine but by placing "Comprehensive" before it it makes it sound like it's referring to a python cheat sheet and not the name of the project.