### PR TITLE
added cumulative sum for list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ List
 ```python
 sum_of_elements  = sum(<collection>)
 elementwise_sum  = [sum(pair) for pair in zip(list_a, list_b)]
+cumulative_sum   = list(itertools.accumulate(<list>))
 sorted_by_second = sorted(<collection>, key=lambda el: el[1])
 sorted_by_both   = sorted(<collection>, key=lambda el: (el[1], el[0]))
 flatter_list     = list(itertools.chain.from_iterable(<list>))


### PR DESCRIPTION
sometimes we need to calculate cumulative sum for a list as follows:
```python
def get_cumulative_sum(num_list: List[int]) -> List[int]:
    cumulative_sum = [0] * len(num_list)
    for i, v in enumerate(num_list):
        cumulative_sum[i] = v + (0 if i == 0 else cumulative_sum[i-1])
    return cumulative_sum
```

but it can be easily done with `itertools.accumulate` as follows:
```python
cumulative_sum = list(itertools.accumulate(<list>))
```