### PR TITLE
subprocess.run: encoding -> text=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -1703,7 +1703,7 @@ import os
 #### Sends '1 + 1' to the basic calculator and captures its output:
 ```python
 >>> from subprocess import run
->>> run('bc', input='1 + 1\n', capture_output=True, encoding='utf-8')
+>>> run('bc', input='1 + 1\n', capture_output=True, text=True)
 CompletedProcess(args='bc', returncode=0, stdout='2\n', stderr='')
 ```
 


### PR DESCRIPTION
I don't think it's good to specify encoding, because console encoding can change.

Though `text=True` needs Py 3.7