### PR TITLE
Timedelta arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ from dateutil.tz import UTC, tzlocal, gettz, datetime_exists, resolve_imaginary
 <TD>     = <D/DTn>  - <D/DTn>               # Returns the difference, ignoring time jumps.
 <TD>     = <DTa>    - <DTa>                 # Ignores time jumps if they share tzinfo object.
 <TD>     = <DT_UTC> - <DT_UTC>              # Convert DTs to UTC to get the actual delta.
+<TD>     = <TD>     / <TD>                  # dt.timedelta(days=365.25) / dt.timedelta(weeks=1)
 ```
 
 


### PR DESCRIPTION
Timedeltas can and should be multiplied and divided, which seems to surprise many people.

If you want to know e.g. how many days or weeks there are in a timedelta, just use division or floor division `//` with the desired unit of time:

```python
>>> dt.timedelta(days=365.25) / dt.timedelta(weeks=1)
52.17857142857143
```

See the [official docs](https://docs.python.org/3.10/library/datetime.html#examples-of-usage-timedelta) for more examples!